### PR TITLE
Add exit button to collapse metadata preview

### DIFF
--- a/src/components/DFR3Viewer.jsx
+++ b/src/components/DFR3Viewer.jsx
@@ -115,7 +115,7 @@ const styles = {
 		margin: "50px auto"
 	},
 	metadataCloseButton:{
-		float:"right",
+		float: "right",
 	}
 };
 

--- a/src/components/DFR3Viewer.jsx
+++ b/src/components/DFR3Viewer.jsx
@@ -113,6 +113,9 @@ const styles = {
 	previewTable:{
 		width: "80%",
 		margin: "50px auto"
+	},
+	metadataCloseButton:{
+		float:"right",
 	}
 };
 
@@ -147,7 +150,8 @@ class DFR3Viewer extends React.Component {
 			confirmOpen: false,
 			deleteType: "curve", // or mapping
 			curvesLoading: false,
-			mappingsLoading: false
+			mappingsLoading: false,
+			metadataClosed: true,
 		};
 
 		this.changeDFR3Type = this.changeDFR3Type.bind(this);
@@ -173,6 +177,7 @@ class DFR3Viewer extends React.Component {
 		this.handlePreviewerClose = this.handlePreviewerClose.bind(this);
 		this.changeDataPerPage = this.changeDataPerPage.bind(this);
 		this.handleSpaceSelection = this.handleSpaceSelection.bind(this);
+		this.closeMetadata = this.closeMetadata.bind(this);
 	}
 
 	async componentWillMount() {
@@ -233,7 +238,8 @@ class DFR3Viewer extends React.Component {
 			offset: 0,
 			pageNumberMappings: 1,
 			offsetMappings: 0,
-			selectedMapping: ""
+			selectedMapping: "",
+			metadataClosed: false,
 		}, function () {
 			this.props.getAllDFR3Curves(this.state.selectedDFR3Type, this.state.selectedSpace, this.state.selectedInventory,
 				this.state.selectedHazard, this.state.dataPerPage, this.state.offset);
@@ -351,13 +357,15 @@ class DFR3Viewer extends React.Component {
 		this.setState({
 			chartConfig: plotConfig2d,
 			plotData3d: plotData3d,
-			selectedDFR3Curve: DFR3Curve
+			selectedDFR3Curve: DFR3Curve,
+			metadataClosed: false,
 		});
 	}
 
 	onClickDFR3Mapping(DFR3Mapping) {
 		this.setState({
-			selectedMapping: DFR3Mapping
+			selectedMapping: DFR3Mapping,
+			metadataClosed: false,
 		});
 	}
 
@@ -623,6 +631,12 @@ class DFR3Viewer extends React.Component {
 		return params;
 	}
 
+	closeMetadata(){
+		this.setState({
+			metadataClosed: true
+		});
+	}
+
 	render() {
 
 		const {classes} = this.props;
@@ -797,9 +811,10 @@ class DFR3Viewer extends React.Component {
 						{/*lists*/}
 						{tabIndex === 0 ?
 							<Grid container spacing={4}>
-								<Grid item lg={this.state.selectedDFR3Curve ? 4 : 12}
-									  md={this.state.selectedDFR3Curve ? 4 : 12}
-									  xl={this.state.selectedDFR3Curve ? 4 : 12} xs={12}>
+								<Grid item lg={this.state.selectedDFR3Curve && !this.state.metadataClosed? 4 : 12}
+									  md={this.state.selectedDFR3Curve && !this.state.metadataClosed? 4 : 12}
+									  xl={this.state.selectedDFR3Curve && !this.state.metadataClosed? 4 : 12}
+									  xs={12}>
 									<LoadingOverlay
 										active={this.state.curvesLoading}
 										spinner
@@ -825,6 +840,10 @@ class DFR3Viewer extends React.Component {
 								<Grid item lg={8} md={8} xl={8} xs={12}
 									  className={this.state.selectedDFR3Curve ? null : classes.hide}>
 									<Paper variant="outlined" className={classes.main}>
+										<IconButton aria-label="Close" onClick={this.closeMetadata}
+											className={classes.metadataCloseButton}>
+											<CloseIcon fontSize="small"/>
+										</IconButton>
 										{Object.keys(selectedCurveDetail).length > 0 ?
 											<div>
 												<div className={classes.paperHeader}>
@@ -944,9 +963,10 @@ class DFR3Viewer extends React.Component {
 
 						{tabIndex === 1 ?
 							<Grid container spacing={4}>
-								<Grid item lg={this.state.selectedMapping ? 4 : 12}
-									  md={this.state.selectedMapping ? 4 : 12}
-									  xl={this.state.selectedMapping ? 4 : 12} xs={12}>
+								<Grid item lg={this.state.selectedMapping && !this.state.metadataClosed? 4 : 12}
+									  md={this.state.selectedMapping && !this.state.metadataClosed? 4 : 12}
+									  xl={this.state.selectedMapping && !this.state.metadataClosed? 4 : 12}
+									  xs={12}>
 									<LoadingOverlay
 										active={this.state.mappingsLoading}
 										spinner
@@ -973,6 +993,10 @@ class DFR3Viewer extends React.Component {
 								<Grid item lg={8} md={8} xl={8} xs={12}
 									  className={this.state.selectedMapping ? null : classes.hide}>
 									<Paper variant="outlined" className={classes.main}>
+										<IconButton aria-label="Close" onClick={this.closeMetadata}
+											className={classes.metadataCloseButton}>
+											<CloseIcon fontSize="small"/>
+										</IconButton>
 										{Object.keys(selectedMappingDetails).length > 0 ?
 											<div>
 												<div className={classes.paperHeader}>

--- a/src/components/DataViewer.jsx
+++ b/src/components/DataViewer.jsx
@@ -111,7 +111,7 @@ const styles = {
 		float: "right"
 	},
 	metadataCloseButton:{
-		float:"right",
+		float: "right",
 	}
 };
 

--- a/src/components/DataViewer.jsx
+++ b/src/components/DataViewer.jsx
@@ -109,6 +109,9 @@ const styles = {
 	previewClose: {
 		display: "inline",
 		float: "right"
+	},
+	metadataCloseButton:{
+		float:"right",
 	}
 };
 
@@ -138,7 +141,8 @@ class DataViewer extends Component {
 			dataPerPage: 50,
 			messageOpen: false,
 			confirmOpen: false,
-			loading: false
+			loading: false,
+			metadataClosed: true,
 		};
 
 		this.changeDatasetType = this.changeDatasetType.bind(this);
@@ -159,6 +163,7 @@ class DataViewer extends Component {
 		this.changeDataPerPage = this.changeDataPerPage.bind(this);
 		this.preview = this.preview.bind(this);
 		this.handlePreviewerClose = this.handlePreviewerClose.bind(this);
+		this.closeMetadata = this.closeMetadata.bind(this);
 	}
 
 	//TODO auto select the first item in the list
@@ -248,7 +253,8 @@ class DataViewer extends Component {
 			selectedDataset: dataset,
 			selectedDatasetFormat: dataset.format,
 			fileData: "",
-			fileExtension: ""
+			fileExtension: "",
+			metadataClosed: false,
 		});
 	}
 
@@ -464,6 +470,12 @@ class DataViewer extends Component {
 	handlePreviewerClose() {
 		this.setState({
 			preview: false
+		});
+	}
+
+	closeMetadata(){
+		this.setState({
+			metadataClosed: true
 		});
 	}
 
@@ -686,8 +698,10 @@ class DataViewer extends Component {
 
 							{/*lists*/}
 
-							<Grid item lg={this.state.selectedDataset ? 4 : 12} md={this.state.selectedDataset ? 4 : 12}
-								xl={this.state.selectedDataset ? 4 : 12} xs={12}>
+							<Grid item lg={this.state.selectedDataset && !this.state.metadataClosed? 4 : 12}
+								  md={this.state.selectedDataset && !this.state.metadataClosed? 4 : 12}
+								  xl={this.state.selectedDataset && !this.state.metadataClosed? 4 : 12}
+								  xs={12}>
 								<LoadingOverlay
 									active={this.state.loading}
 									spinner
@@ -715,6 +729,10 @@ class DataViewer extends Component {
 							<Grid item lg={8} md={8} xl={8} xs={12}
 								  className={this.state.selectedDataset ? null : classes.hide}>
 								<Paper variant="outlined" className={classes.main}>
+									<IconButton aria-label="Close" onClick={this.closeMetadata}
+										className={classes.metadataCloseButton}>
+										<CloseIcon fontSize="small"/>
+									</IconButton>
 									{Object.keys(selected_dataset_detail).length > 0 ?
 										<div>
 											<div className={classes.paperHeader}>

--- a/src/components/HazardViewer.jsx
+++ b/src/components/HazardViewer.jsx
@@ -101,6 +101,9 @@ const styles = {
 	previewClose: {
 		display: "inline",
 		float: "right"
+	},
+	metadataCloseButton:{
+		float:"right",
 	}
 };
 
@@ -125,7 +128,8 @@ class HazardViewer extends Component {
 			preview: false,
 			messageOpen: false,
 			confirmOpen: false,
-			loading: false
+			loading: false,
+			metadataClosed: true,
 		};
 		this.changeHazardType = this.changeHazardType.bind(this);
 		this.onClickHazard = this.onClickHazard.bind(this);
@@ -143,6 +147,7 @@ class HazardViewer extends Component {
 		this.changeDataPerPage = this.changeDataPerPage.bind(this);
 		this.preview = this.preview.bind(this);
 		this.handlePreviewerClose = this.handlePreviewerClose.bind(this);
+		this.closeMetadata = this.closeMetadata.bind(this);
 	}
 
 	componentWillMount() {
@@ -220,7 +225,11 @@ class HazardViewer extends Component {
 
 	onClickHazard(hazardId) {
 		const hazard = this.props.hazards.find(hazard => hazard.id === hazardId);
-		this.setState({selectedHazard: hazard, selectedHazardDatasetId: ""});
+		this.setState({
+			selectedHazard: hazard,
+			selectedHazardDatasetId: "",
+			metadataClosed: false,
+		});
 	}
 
 
@@ -388,6 +397,12 @@ class HazardViewer extends Component {
 		});
 	}
 
+	closeMetadata(){
+		this.setState({
+			metadataClosed: true
+		});
+	}
+
 	render() {
 
 		const {classes} = this.props;
@@ -501,9 +516,10 @@ class HazardViewer extends Component {
 							</Grid>
 
 							{/*lists*/}
-							<Grid item lg={this.state.selectedHazard ? 4 : 12}
-								  md={this.state.selectedHazard ? 4 : 12}
-								  xl={this.state.selectedHazard ? 4 : 12} xs={12}>
+							<Grid item lg={this.state.selectedHazard && !this.state.metadataClosed? 4 : 12}
+								  md={this.state.selectedHazard && !this.state.metadataClosed? 4 : 12}
+								  xl={this.state.selectedHazard && !this.state.metadataClosed? 4 : 12}
+								  xs={12}>
 								<LoadingOverlay
 									active={this.state.loading}
 									spinner
@@ -528,6 +544,10 @@ class HazardViewer extends Component {
 							<Grid item lg={8} md={8} xl={8} xs={12}
 								  className={this.state.selectedHazard ? null : classes.hide}>
 								<Paper variant="outlined" className={classes.main}>
+									<IconButton aria-label="Close" onClick={this.closeMetadata}
+										className={classes.metadataCloseButton}>
+										<CloseIcon fontSize="small"/>
+									</IconButton>
 									{Object.keys(selected_hazard_detail).length > 0 ?
 										<div>
 											<div className={classes.paperHeader}>

--- a/src/components/HazardViewer.jsx
+++ b/src/components/HazardViewer.jsx
@@ -102,8 +102,8 @@ const styles = {
 		display: "inline",
 		float: "right"
 	},
-	metadataCloseButton:{
-		float:"right",
+	metadataCloseButton: {
+		float: "right",
 	}
 };
 
@@ -239,7 +239,7 @@ class HazardViewer extends Component {
 		});
 	}
 
-	handleConfirmed(){
+	handleConfirmed() {
 		this.props.deleteItemById(this.state.selectedHazardType, this.state.selectedHazard.id);
 		this.setState({
 			selectedHazard: "",
@@ -248,7 +248,7 @@ class HazardViewer extends Component {
 		});
 	}
 
-	handleCanceled(){
+	handleCanceled() {
 		this.setState({
 			confirmOpen: false
 		});
@@ -397,7 +397,7 @@ class HazardViewer extends Component {
 		});
 	}
 
-	closeMetadata(){
+	closeMetadata() {
 		this.setState({
 			metadataClosed: true
 		});
@@ -450,7 +450,7 @@ class HazardViewer extends Component {
 								  actionBtnName="Delete"
 								  actionText="Once deleted, you won't be able to revert this!"
 								  handleConfirmed={this.handleConfirmed}
-								  handleCanceled={this.handleCanceled} />
+								  handleCanceled={this.handleCanceled}/>
 					<div className={classes.root}>
 						<Grid container spacing={4}>
 							{/*filters*/}
@@ -461,7 +461,7 @@ class HazardViewer extends Component {
 									<div className={classes.selectDiv}>
 										<InputLabel>Hazard Type</InputLabel>
 										<Select value={this.state.selectedHazardType} onChange={this.changeHazardType}
-											className={classes.select}>
+												className={classes.select}>
 											<MenuItem value="earthquakes" key="earthquakes"
 													  className={classes.denseStyle}>Earthquake</MenuItem>
 											<MenuItem value="tornadoes" key="tornadoes"
@@ -516,9 +516,9 @@ class HazardViewer extends Component {
 							</Grid>
 
 							{/*lists*/}
-							<Grid item lg={this.state.selectedHazard && !this.state.metadataClosed? 4 : 12}
-								  md={this.state.selectedHazard && !this.state.metadataClosed? 4 : 12}
-								  xl={this.state.selectedHazard && !this.state.metadataClosed? 4 : 12}
+							<Grid item lg={this.state.selectedHazard && !this.state.metadataClosed ? 4 : 12}
+								  md={this.state.selectedHazard && !this.state.metadataClosed ? 4 : 12}
+								  xl={this.state.selectedHazard && !this.state.metadataClosed ? 4 : 12}
 								  xs={12}>
 								<LoadingOverlay
 									active={this.state.loading}
@@ -531,10 +531,10 @@ class HazardViewer extends Component {
 										{hazards_list_display}
 										<div className={classes.paperFooter}>
 											<Pagination pageNumber={this.state.pageNumber}
-												data={hazards_list_display}
-												dataPerPage={this.state.dataPerPage}
-												previous={this.previous}
-												next={this.next}/>
+														data={hazards_list_display}
+														dataPerPage={this.state.dataPerPage}
+														previous={this.previous}
+														next={this.next}/>
 										</div>
 									</Paper>
 								</LoadingOverlay>
@@ -545,7 +545,7 @@ class HazardViewer extends Component {
 								  className={this.state.selectedHazard ? null : classes.hide}>
 								<Paper variant="outlined" className={classes.main}>
 									<IconButton aria-label="Close" onClick={this.closeMetadata}
-										className={classes.metadataCloseButton}>
+												className={classes.metadataCloseButton}>
 										<CloseIcon fontSize="small"/>
 									</IconButton>
 									{Object.keys(selected_hazard_detail).length > 0 ?
@@ -555,19 +555,19 @@ class HazardViewer extends Component {
 											</div>
 											<div className={classes.metadata}>
 												<Button color="primary" variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.exportJson}>Download Metadata</Button>
+														className={classes.inlineButtons}
+														size="small"
+														onClick={this.exportJson}>Download Metadata</Button>
 												<CopyToClipboard text={this.state.selectedHazard.id}>
 													<Button color="secondary" variant="contained"
-														className={classes.inlineButtons}
-														size="small">Copy ID</Button>
+															className={classes.inlineButtons}
+															size="small">Copy ID</Button>
 												</CopyToClipboard>
 												<Button color="secondary"
-													variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.onClickDelete}>
+														variant="contained"
+														className={classes.inlineButtons}
+														size="small"
+														onClick={this.onClickDelete}>
 													DELETE
 												</Button>
 											</div>
@@ -589,10 +589,10 @@ class HazardViewer extends Component {
 					{/* Preview */}
 					{this.state.selectedHazard ?
 						<Dialog open={this.state.preview} onClose={this.handlePreviewerClose} maxWidth="lg" fullWidth
-							scroll="paper">
+								scroll="paper">
 							<DialogContent className={classes.preview}>
 								<IconButton aria-label="Close" onClick={this.handlePreviewerClose}
-									className={classes.previewClose}>
+											className={classes.previewClose}>
 									<CloseIcon fontSize="small"/>
 								</IconButton>
 								<div>

--- a/src/components/HazardViewer.jsx
+++ b/src/components/HazardViewer.jsx
@@ -461,7 +461,7 @@ class HazardViewer extends Component {
 									<div className={classes.selectDiv}>
 										<InputLabel>Hazard Type</InputLabel>
 										<Select value={this.state.selectedHazardType} onChange={this.changeHazardType}
-												className={classes.select}>
+											className={classes.select}>
 											<MenuItem value="earthquakes" key="earthquakes"
 													  className={classes.denseStyle}>Earthquake</MenuItem>
 											<MenuItem value="tornadoes" key="tornadoes"
@@ -531,10 +531,10 @@ class HazardViewer extends Component {
 										{hazards_list_display}
 										<div className={classes.paperFooter}>
 											<Pagination pageNumber={this.state.pageNumber}
-														data={hazards_list_display}
-														dataPerPage={this.state.dataPerPage}
-														previous={this.previous}
-														next={this.next}/>
+												data={hazards_list_display}
+												dataPerPage={this.state.dataPerPage}
+												previous={this.previous}
+												next={this.next}/>
 										</div>
 									</Paper>
 								</LoadingOverlay>
@@ -545,7 +545,7 @@ class HazardViewer extends Component {
 								  className={this.state.selectedHazard ? null : classes.hide}>
 								<Paper variant="outlined" className={classes.main}>
 									<IconButton aria-label="Close" onClick={this.closeMetadata}
-												className={classes.metadataCloseButton}>
+										className={classes.metadataCloseButton}>
 										<CloseIcon fontSize="small"/>
 									</IconButton>
 									{Object.keys(selected_hazard_detail).length > 0 ?
@@ -555,19 +555,19 @@ class HazardViewer extends Component {
 											</div>
 											<div className={classes.metadata}>
 												<Button color="primary" variant="contained"
-														className={classes.inlineButtons}
-														size="small"
-														onClick={this.exportJson}>Download Metadata</Button>
+													className={classes.inlineButtons}
+													size="small"
+													onClick={this.exportJson}>Download Metadata</Button>
 												<CopyToClipboard text={this.state.selectedHazard.id}>
 													<Button color="secondary" variant="contained"
-															className={classes.inlineButtons}
-															size="small">Copy ID</Button>
+														className={classes.inlineButtons}
+														size="small">Copy ID</Button>
 												</CopyToClipboard>
 												<Button color="secondary"
-														variant="contained"
-														className={classes.inlineButtons}
-														size="small"
-														onClick={this.onClickDelete}>
+													variant="contained"
+													className={classes.inlineButtons}
+													size="small"
+													onClick={this.onClickDelete}>
 													DELETE
 												</Button>
 											</div>
@@ -589,10 +589,10 @@ class HazardViewer extends Component {
 					{/* Preview */}
 					{this.state.selectedHazard ?
 						<Dialog open={this.state.preview} onClose={this.handlePreviewerClose} maxWidth="lg" fullWidth
-								scroll="paper">
+							scroll="paper">
 							<DialogContent className={classes.preview}>
 								<IconButton aria-label="Close" onClick={this.handlePreviewerClose}
-											className={classes.previewClose}>
+									className={classes.previewClose}>
 									<CloseIcon fontSize="small"/>
 								</IconButton>
 								<div>


### PR DESCRIPTION
A close button on the top right side of the metadata window has been added to close the preview for the currently selected entity.