### PR TITLE
call the endpoint itself on tab selection

### DIFF
--- a/landing.conf
+++ b/landing.conf
@@ -6,6 +6,7 @@ server {
     #root /incore-ui/dist;
     index index.html;
     try_files $uri /index.html;
+    add_header Cache-Control 'no-store';
   }
   location /public/ {
     root /usr/share/nginx/html;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -333,16 +333,19 @@ class App extends Component {
 						  onClick={() => {
 							  this.handleViewerMenuClose();
 							  browserHistory.push("/DFR3Viewer");
+							  fetch("/DFR3Viewer");
 						  }}>DFR3 Viewer</MenuItem>
 				<MenuItem className={classes.denseStyle}
 						  onClick={() => {
 							  this.handleViewerMenuClose();
 							  browserHistory.push("/DataViewer");
+							  fetch("/DataViewer");
 						  }}>Data Viewer</MenuItem>
 				<MenuItem className={classes.denseStyle}
 						  onClick={() => {
 							  this.handleViewerMenuClose();
 							  browserHistory.push("/HazardViewer");
+							  fetch("/HazardViewer");
 						  }}>Hazard Viewer</MenuItem>
 			</Menu>
 		);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -401,8 +401,12 @@ class App extends Component {
 							User Guides<ExpandMoreIcon fontSize="small"/></Typography>
 						{helpMenu}
 						<Typography className={classes.toolBarItem}>
-							<Link href={config.incoreLab} target="_blank"
-								  style={{color: "#ffffff", textDecoration: "none"}}>
+							<Link target="_blank"
+								  style={{color: "#ffffff", textDecoration: "none"}}
+								  onClick={() => {
+									  window.open(config.incoreLab);
+									  fetch("/jupyterhub");
+								  }}>
 								IN-CORE lab</Link></Typography>
 						<Typography onClick={this.handleViewerMenuOpen} className={classes.toolBarItem}
 							style={{verticalAlign: "middle", display: "inline-flex"}}>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -15,7 +15,7 @@
   <script src="https://d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js"></script>
   <% } %>
 
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="X-UA-Compatible" content='no-cache'>
   <meta charset="utf-8"/>
   <title>IN-CORE</title>
 </head>


### PR DESCRIPTION
whenever select a viewer, it calls the document itself; then INCORE-auth would be able to pick it up and record as 1 time visit of the page
![image](https://user-images.githubusercontent.com/13950475/148291675-dd9c9a39-74be-41dc-890d-ebd3f4016350.png)
