### PR TITLE
Fixes #78 - changelog links were wrong after branch renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## Unreleased
+## [Unreleased]
 ### Changed
 - Use github release instead of github tag to display the latest versions on the landing page [#77](https://github.com/IN-CORE/incore-ui/pull/77)
+- Update CHANGELOG link for branch renaming [#78](https://github.com/IN-CORE/incore-ui/issues/78)
 
 
 ## [1.0.1] - 2022-03-30

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -166,7 +166,7 @@ class HomePage extends Component {
 				title: "pyIncore",
 				repoName: "pyincore",
 				options: {
-					"Change log": "https://github.com/IN-CORE/pyincore/blob/master/CHANGELOG.md",
+					"Change log": "https://github.com/IN-CORE/pyincore/blob/main/CHANGELOG.md",
 					"GitHub": "https://github.com/IN-CORE/pyincore",
 					"Conda package": "https://anaconda.org/in-core/pyincore",
 				}
@@ -175,7 +175,7 @@ class HomePage extends Component {
 				title: "pyIncore-viz",
 				repoName: "pyincore-viz",
 				options: {
-					"Change log": "https://github.com/IN-CORE/pyincore-viz/blob/master/CHANGELOG.md",
+					"Change log": "https://github.com/IN-CORE/pyincore-viz/blob/main/CHANGELOG.md",
 					"GitHub": "https://github.com/IN-CORE/pyincore-viz",
 					"Conda package": "https://anaconda.org/in-core/pyincore-viz",
 				}
@@ -184,7 +184,7 @@ class HomePage extends Component {
 				title: "pyIncore-data",
 				repoName: "pyincore-data",
 				options: {
-					"Change log": "https://github.com/IN-CORE/pyincore-data/blob/master/CHANGELOG.md",
+					"Change log": "https://github.com/IN-CORE/pyincore-data/blob/main/CHANGELOG.md",
 					"GitHub": "https://github.com/IN-CORE/pyincore-data",
 					"Conda package": "https://anaconda.org/in-core/pyincore-data",
 				}
@@ -193,7 +193,7 @@ class HomePage extends Component {
 				title: "Web Services",
 				repoName:"incore-services",
 				options: {
-					"Change log": "https://github.com/IN-CORE/incore-services/blob/master/CHANGELOG.md",
+					"Change log": "https://github.com/IN-CORE/incore-services/blob/main/CHANGELOG.md",
 					"GitHub": "https://github.com/IN-CORE/incore-services"
 				}
 			},
@@ -201,7 +201,7 @@ class HomePage extends Component {
 				title: "Web Tools",
 				repoName: "incore-ui",
 				options: {
-					"Change log": "https://github.com/IN-CORE/incore-ui/blob/master/CHANGELOG.md",
+					"Change log": "https://github.com/IN-CORE/incore-ui/blob/main/CHANGELOG.md",
 					"GitHub": "https://github.com/IN-CORE/incore-ui"
 				}
 			},
@@ -209,7 +209,7 @@ class HomePage extends Component {
 				title: "IN-CORE Lab",
 				repoName: "incore-lab",
 				options: {
-					"Change log": "https://github.com/IN-CORE/incore-lab/blob/master/CHANGELOG.md",
+					"Change log": "https://github.com/IN-CORE/incore-lab/blob/main/CHANGELOG.md",
 					"GitHub": "https://github.com/IN-CORE/incore-lab"
 				}
 			},


### PR DESCRIPTION
incore-lab branch needs to be renamed for this to work. I updated that to point at "main" assuming we'll rename the branch. 