### PR TITLE
110 when user has no usage display zero instead of undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [Unreleased]
+### Fixed
+- When-user-has-no-usage-display-zero-instead-of-undefined [#110](https://github.com/IN-CORE/incore-ui/issues/110)
+
+
 ## [1.6.0] - 2023-04-25
-
 ### Changed
-
 - Change the getVersionTags scripts to get tags from the central IN-CORE repository.[#104](https://github.com/IN-CORE/incore-ui/issues/104)
 
-## [1.5.0] - 2023-03-15
 
+## [1.5.0] - 2023-03-15
 ### Changed
 - builds are done on amd64 and then artifact copied to different platforms.
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -287,13 +287,13 @@ class App extends Component {
 							variant="determinate"
 							className={classes.customProgressBar}
 							value={
-								(this.props.usage["total_file_size_of_datasets_byte"] /
+								((this.props.usage["total_file_size_of_datasets_byte"] ?? 0)/
 									this.props.allocations["total_file_size_of_datasets_byte"]) *
 								100
 							}
 						/>
 						<Typography className={classes.fontLight} style={{ fontSize: "10px" }}>
-							Data {this.props.usage["total_file_size_of_datasets"]} of{" "}
+							Data {this.props.usage["total_file_size_of_datasets"] ?? 0} of{" "}
 							{this.props.allocations["total_file_size_of_datasets"]} used
 						</Typography>
 					</Box>
@@ -302,13 +302,13 @@ class App extends Component {
 							variant="determinate"
 							className={classes.customProgressBar}
 							value={
-								(this.props.usage["total_file_size_of_hazard_datasets_byte"] /
+								((this.props.usage["total_file_size_of_hazard_datasets_byte"] ?? 0) /
 									this.props.allocations["total_file_size_of_hazard_datasets_byte"]) *
 								100
 							}
 						/>
 						<Typography className={classes.fontLight} style={{ fontSize: "10px" }}>
-							Hazard {this.props.usage["total_file_size_of_hazard_datasets"]} of{" "}
+							Hazard {this.props.usage["total_file_size_of_hazard_datasets"] ?? 0} of{" "}
 							{this.props.allocations["total_file_size_of_hazard_datasets"]} used
 						</Typography>
 					</Box>

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -180,19 +180,19 @@ export default function Profile(props) {
 		let totalBytesTextAllocated = "NA";
 
 		if (type === "datasetUsage") {
-			totalNum = usage["total_number_of_datasets"];
-			totalFileSizeByte = usage["total_file_size_of_datasets_byte"];
-			totalFileSize = usage["total_file_size_of_datasets"];
-			totalNumAllocated = allocations["total_number_of_datasets"];
-			totalBytesAllocated = allocations["total_file_size_of_datasets_byte"];
-			totalBytesTextAllocated = allocations["total_file_size_of_datasets"];
+			totalNum = usage["total_number_of_datasets"] ?? 0;
+			totalFileSizeByte = usage["total_file_size_of_datasets_byte"] ?? 0;
+			totalFileSize = usage["total_file_size_of_datasets"] ?? 0;
+			totalNumAllocated = allocations["total_number_of_datasets"] ?? 0;
+			totalBytesAllocated = allocations["total_file_size_of_datasets_byte"] ?? 0;
+			totalBytesTextAllocated = allocations["total_file_size_of_datasets"] ?? 0;
 		} else if (type === "hazardUsage") {
-			totalNum = usage["total_number_of_hazards"];
-			totalFileSizeByte = usage["total_file_size_of_hazard_datasets_byte"];
-			totalFileSize = usage["total_file_size_of_hazard_datasets"];
-			totalNumAllocated = allocations["total_number_of_hazards"];
-			totalBytesAllocated = allocations["total_file_size_of_hazard_datasets_byte"];
-			totalBytesTextAllocated = allocations["total_file_size_of_hazard_datasets"];
+			totalNum = usage["total_number_of_hazards"] ?? 0;
+			totalFileSizeByte = usage["total_file_size_of_hazard_datasets_byte"] ?? 0;
+			totalFileSize = usage["total_file_size_of_hazard_datasets"] ?? 0;
+			totalNumAllocated = allocations["total_number_of_hazards"] ?? 0;
+			totalBytesAllocated = allocations["total_file_size_of_hazard_datasets_byte"] ?? 0;
+			totalBytesTextAllocated = allocations["total_file_size_of_hazard_datasets"] ?? 0;
 		} else {
 			console.log(`${type} not supported!`);
 		}


### PR DESCRIPTION
To test:

- run `npm run start:dev`

- Login with custom created user 
username: testallocation
password: 1234567

- dropdown should show 0 out of xxx
<img width="239" alt="image" src="https://user-images.githubusercontent.com/13950475/236937507-5788cc09-8c11-488e-bdcb-4e181c2b866b.png">

- go to profile page: 
<img width="693" alt="image" src="https://user-images.githubusercontent.com/13950475/236937451-aa928316-11eb-4970-84eb-9d153bbc5a23.png">


you can compare with the same account login on https://incore-dev.ncsa.illinois.edu