### PR TITLE
124 improper functionality when close icon is clicked on dataviewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - When-user-has-no-usage-display-zero-instead-of-undefined [#110](https://github.com/IN-CORE/incore-ui/issues/110)
 - Github action to grab correct version when merged to main. [#115](https://github.com/IN-CORE/incore-ui/issues/115)
+- Improper functionality when close icon is clicked [#124](https://github.com/IN-CORE/incore-ui/issues/124)
 
 
 ## [1.6.0] - 2023-04-25

--- a/src/components/DFR3Viewer.jsx
+++ b/src/components/DFR3Viewer.jsx
@@ -87,9 +87,6 @@ const styles = {
 		display: "inline-block",
 		margin: "auto 5px"
 	},
-	hide: {
-		display: "none"
-	},
 	paperFooter: {
 		padding: theme.spacing(2),
 		borderTop: "1px solid #eeeeee",
@@ -1034,133 +1031,137 @@ class DFR3Viewer extends React.Component {
 										</Paper>
 									</LoadingOverlay>
 								</Grid>
-								<Grid
-									item
-									lg={8}
-									md={8}
-									xl={8}
-									xs={12}
-									className={this.state.selectedDFR3Curve ? null : classes.hide}
-								>
-									<Paper variant="outlined" className={classes.main}>
-										<IconButton
-											aria-label="Close"
-											onClick={this.closeMetadata}
-											className={classes.metadataCloseButton}
+								{
+									this.state.metadataClosed ?
+										<></>
+										:
+										<Grid
+											item
+											lg={8}
+											md={8}
+											xl={8}
+											xs={12}
 										>
-											<CloseIcon fontSize="small" />
-										</IconButton>
-										{Object.keys(selectedCurveDetail).length > 0 ? (
-											<div>
-												<div className={classes.paperHeader}>
-													<Typography variant="subtitle1">Metadata</Typography>
-												</div>
-												<div className={classes.metadata}>
-													<Button
-														color="primary"
-														variant="contained"
-														className={classes.inlineButtons}
-														size="small"
-														onClick={this.exportCurveJson}
-													>
-														Download Metadata
-													</Button>
-													{
-														// TODO: This should be updated with conditions for repair and restoration
-														//  curves when they are refactored to new equation based format
-														// 	cannot plot 3d refactored fragility curves yet
+											<Paper variant="outlined" className={classes.main}>
+												<IconButton
+													aria-label="Close"
+													onClick={this.closeMetadata}
+													className={classes.metadataCloseButton}
+												>
+													<CloseIcon fontSize="small" />
+												</IconButton>
+												{Object.keys(selectedCurveDetail).length > 0 ? (
+													<div>
+														<div className={classes.paperHeader}>
+															<Typography variant="subtitle1">Metadata</Typography>
+														</div>
+														<div className={classes.metadata}>
+															<Button
+																color="primary"
+																variant="contained"
+																className={classes.inlineButtons}
+																size="small"
+																onClick={this.exportCurveJson}
+															>
+																Download Metadata
+															</Button>
+															{
+																// TODO: This should be updated with conditions for repair and restoration
+																//  curves when they are refactored to new equation based format
+																// 	cannot plot 3d refactored fragility curves yet
 
-														(() => {
-															if (this.state.selectedDFR3Curve.fragilityCurves) {
-																if (
-																	this.state.selectedDFR3Curve.is3dPlot &&
-																	this.state.plotData3d.data.length > 0
-																) {
-																	return (
-																		<Button
-																			color="primary"
-																			variant="contained"
-																			className={classes.inlineButtons}
-																			size="small"
-																			onClick={this.preview}
-																		>
-																			Preview
-																		</Button>
-																	);
-																} else if (
-																	!this.state.selectedDFR3Curve.is3dPlot &&
-																	this.state.chartConfig.series.length > 0
-																) {
-																	return (
-																		<Button
-																			color="primary"
-																			variant="contained"
-																			className={classes.inlineButtons}
-																			size="small"
-																			onClick={this.preview}
-																		>
-																			Preview
-																		</Button>
-																	);
-																} else {
-																	return (
-																		<Button
-																			color="primary"
-																			variant="contained"
-																			className={classes.inlineButtons}
-																			size="small"
-																			disabled
-																		>
-																			Preview N/A
-																		</Button>
-																	);
-																}
-															} else {
-																return (
-																	<Button
-																		color="primary"
-																		variant="contained"
-																		className={classes.inlineButtons}
-																		size="small"
-																		disabled
-																	>
-																		Preview N/A
-																	</Button>
-																);
+																(() => {
+																	if (this.state.selectedDFR3Curve.fragilityCurves) {
+																		if (
+																			this.state.selectedDFR3Curve.is3dPlot &&
+																			this.state.plotData3d.data.length > 0
+																		) {
+																			return (
+																				<Button
+																					color="primary"
+																					variant="contained"
+																					className={classes.inlineButtons}
+																					size="small"
+																					onClick={this.preview}
+																				>
+																					Preview
+																				</Button>
+																			);
+																		} else if (
+																			!this.state.selectedDFR3Curve.is3dPlot &&
+																			this.state.chartConfig.series.length > 0
+																		) {
+																			return (
+																				<Button
+																					color="primary"
+																					variant="contained"
+																					className={classes.inlineButtons}
+																					size="small"
+																					onClick={this.preview}
+																				>
+																					Preview
+																				</Button>
+																			);
+																		} else {
+																			return (
+																				<Button
+																					color="primary"
+																					variant="contained"
+																					className={classes.inlineButtons}
+																					size="small"
+																					disabled
+																				>
+																					Preview N/A
+																				</Button>
+																			);
+																		}
+																	} else {
+																		return (
+																			<Button
+																				color="primary"
+																				variant="contained"
+																				className={classes.inlineButtons}
+																				size="small"
+																				disabled
+																			>
+																				Preview N/A
+																			</Button>
+																		);
+																	}
+																})()
 															}
-														})()
-													}
-													<CopyToClipboard text={this.state.selectedDFR3Curve.id}>
-														<Button
-															color="secondary"
-															variant="contained"
-															className={classes.inlineButtons}
-															size="small"
-														>
-															Copy ID
-														</Button>
-													</CopyToClipboard>
-													<Button
-														color="secondary"
-														variant="contained"
-														className={classes.inlineButtons}
-														size="small"
-														onClick={() => {
-															this.onClickDelete("curve");
-														}}
-													>
-														DELETE
-													</Button>
-												</div>
-												<div className={classes.metadata}>
-													<NestedInfoTable data={selectedCurveDetail} />
-												</div>
-											</div>
-										) : (
-											<div />
-										)}
-									</Paper>
-								</Grid>
+															<CopyToClipboard text={this.state.selectedDFR3Curve.id}>
+																<Button
+																	color="secondary"
+																	variant="contained"
+																	className={classes.inlineButtons}
+																	size="small"
+																>
+																	Copy ID
+																</Button>
+															</CopyToClipboard>
+															<Button
+																color="secondary"
+																variant="contained"
+																className={classes.inlineButtons}
+																size="small"
+																onClick={() => {
+																	this.onClickDelete("curve");
+																}}
+															>
+																DELETE
+															</Button>
+														</div>
+														<div className={classes.metadata}>
+															<NestedInfoTable data={selectedCurveDetail} />
+														</div>
+													</div>
+												) : (
+													<div />
+												)}
+											</Paper>
+										</Grid>
+								}
 
 								{/* Preview */}
 								{this.state.selectedDFR3Curve ? (

--- a/src/components/DataViewer.jsx
+++ b/src/components/DataViewer.jsx
@@ -88,9 +88,6 @@ const styles = {
 		display: "inline-block",
 		margin: "auto 5px"
 	},
-	hide: {
-		display: "none"
-	},
 	paperFooter: {
 		padding: theme.spacing(2),
 		borderTop: "1px solid #eeeeee",
@@ -810,7 +807,6 @@ class DataViewer extends Component {
 							</Grid>
 
 							{/*lists*/}
-
 							<Grid
 								item
 								lg={this.state.selectedDataset && !this.state.metadataClosed ? 4 : 12}
@@ -838,85 +834,88 @@ class DataViewer extends Component {
 							</Grid>
 
 							{/*metadata*/}
-							<Grid
-								item
-								lg={8}
-								md={8}
-								xl={8}
-								xs={12}
-								className={this.state.selectedDataset ? null : classes.hide}
-							>
-								<Paper variant="outlined" className={classes.main}>
-									<IconButton
-										aria-label="Close"
-										onClick={this.closeMetadata}
-										className={classes.metadataCloseButton}
-									>
-										<CloseIcon fontSize="small" />
-									</IconButton>
-									{Object.keys(selected_dataset_detail).length > 0 ? (
-										<div>
-											<div className={classes.paperHeader}>
-												<Typography variant="subtitle1">Metadata</Typography>
-											</div>
-											<div className={classes.metadata}>
-												<Button
-													color="primary"
-													variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.exportJson}
-												>
-													Download Metadata
-												</Button>
-												<Button
-													color="primary"
-													variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.downloadDataset}
-												>
-													Download Dataset
-												</Button>
-												<Button
-													color="primary"
-													variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.preview}
-												>
-													Preview
-												</Button>
-												<CopyToClipboard text={this.state.selectedDataset.id}>
+							{ this.state.metadataClosed ?
+								<></>
+								:
+								<Grid
+									item
+									lg={8}
+									md={8}
+									xl={8}
+									xs={12}
+								>
+									<Paper variant="outlined" className={classes.main}>
+										<IconButton
+											aria-label="Close"
+											onClick={this.closeMetadata}
+											className={classes.metadataCloseButton}
+										>
+											<CloseIcon fontSize="small" />
+										</IconButton>
+										{Object.keys(selected_dataset_detail).length > 0 ? (
+											<div>
+												<div className={classes.paperHeader}>
+													<Typography variant="subtitle1">Metadata</Typography>
+												</div>
+												<div className={classes.metadata}>
+													<Button
+														color="primary"
+														variant="contained"
+														className={classes.inlineButtons}
+														size="small"
+														onClick={this.exportJson}
+													>
+														Download Metadata
+													</Button>
+													<Button
+														color="primary"
+														variant="contained"
+														className={classes.inlineButtons}
+														size="small"
+														onClick={this.downloadDataset}
+													>
+														Download Dataset
+													</Button>
+													<Button
+														color="primary"
+														variant="contained"
+														className={classes.inlineButtons}
+														size="small"
+														onClick={this.preview}
+													>
+														Preview
+													</Button>
+													<CopyToClipboard text={this.state.selectedDataset.id}>
+														<Button
+															color="secondary"
+															variant="contained"
+															className={classes.inlineButtons}
+															size="small"
+														>
+															Copy ID
+														</Button>
+													</CopyToClipboard>
 													<Button
 														color="secondary"
 														variant="contained"
 														className={classes.inlineButtons}
 														size="small"
+														onClick={this.onClickDelete}
 													>
-														Copy ID
+														DELETE
 													</Button>
-												</CopyToClipboard>
-												<Button
-													color="secondary"
-													variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.onClickDelete}
-												>
-													DELETE
-												</Button>
+												</div>
+												<div className={classes.metadata}>
+													<NestedInfoTable data={selected_dataset_detail} />
+												</div>
 											</div>
-											<div className={classes.metadata}>
-												<NestedInfoTable data={selected_dataset_detail} />
-											</div>
-										</div>
-									) : (
-										<div />
-									)}
-								</Paper>
+										) : (
+											<div />
+										)}
+									</Paper>
+								</Grid>
+							}
 							</Grid>
-						</Grid>
 						{/*version*/}
 						<Version />
 					</div>

--- a/src/components/HazardViewer.jsx
+++ b/src/components/HazardViewer.jsx
@@ -80,9 +80,6 @@ const styles = {
 		display: "inline-block",
 		margin: "auto 5px"
 	},
-	hide: {
-		display: "none"
-	},
 	paperFooter: {
 		padding: theme.spacing(2),
 		borderTop: "1px solid #eeeeee",
@@ -645,70 +642,74 @@ class HazardViewer extends Component {
 							</Grid>
 
 							{/* Metadata */}
-							<Grid
-								item
-								lg={8}
-								md={8}
-								xl={8}
-								xs={12}
-								className={this.state.selectedHazard ? null : classes.hide}
-							>
-								<Paper variant="outlined" className={classes.main}>
-									<IconButton
-										aria-label="Close"
-										onClick={this.closeMetadata}
-										className={classes.metadataCloseButton}
+							{
+								this.state.metadataClosed ?
+									<></>
+									:
+									<Grid
+										item
+										lg={8}
+										md={8}
+										xl={8}
+										xs={12}
 									>
-										<CloseIcon fontSize="small" />
-									</IconButton>
-									{Object.keys(selected_hazard_detail).length > 0 ? (
-										<div>
-											<div className={classes.paperHeader}>
-												<Typography variant="subtitle1">Metadata</Typography>
-											</div>
-											<div className={classes.metadata}>
-												<Button
-													color="primary"
-													variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.exportJson}
-												>
-													Download Metadata
-												</Button>
-												<CopyToClipboard text={this.state.selectedHazard.id}>
-													<Button
-														color="secondary"
-														variant="contained"
-														className={classes.inlineButtons}
-														size="small"
-													>
-														Copy ID
-													</Button>
-												</CopyToClipboard>
-												<Button
-													color="secondary"
-													variant="contained"
-													className={classes.inlineButtons}
-													size="small"
-													onClick={this.onClickDelete}
-												>
-													DELETE
-												</Button>
-											</div>
-											<div className={classes.metadata}>
-												<NestedInfoTable
-													data={selected_hazard_detail}
-													selectedHazardDataset={this.state.selectedHazardDatasetId}
-													onClick={this.preview}
-												/>
-											</div>
-										</div>
-									) : (
-										<div />
-									)}
-								</Paper>
-							</Grid>
+										<Paper variant="outlined" className={classes.main}>
+											<IconButton
+												aria-label="Close"
+												onClick={this.closeMetadata}
+												className={classes.metadataCloseButton}
+											>
+												<CloseIcon fontSize="small" />
+											</IconButton>
+											{Object.keys(selected_hazard_detail).length > 0 ? (
+												<div>
+													<div className={classes.paperHeader}>
+														<Typography variant="subtitle1">Metadata</Typography>
+													</div>
+													<div className={classes.metadata}>
+														<Button
+															color="primary"
+															variant="contained"
+															className={classes.inlineButtons}
+															size="small"
+															onClick={this.exportJson}
+														>
+															Download Metadata
+														</Button>
+														<CopyToClipboard text={this.state.selectedHazard.id}>
+															<Button
+																color="secondary"
+																variant="contained"
+																className={classes.inlineButtons}
+																size="small"
+															>
+																Copy ID
+															</Button>
+														</CopyToClipboard>
+														<Button
+															color="secondary"
+															variant="contained"
+															className={classes.inlineButtons}
+															size="small"
+															onClick={this.onClickDelete}
+														>
+															DELETE
+														</Button>
+													</div>
+													<div className={classes.metadata}>
+														<NestedInfoTable
+															data={selected_hazard_detail}
+															selectedHazardDataset={this.state.selectedHazardDatasetId}
+															onClick={this.preview}
+														/>
+													</div>
+												</div>
+											) : (
+												<div />
+											)}
+										</Paper>
+									</Grid>
+							}
 						</Grid>
 						<Version />
 					</div>


### PR DESCRIPTION
To test:
- npm install (if you have never installed)
- npm run start:dev
- go to any of the viewer click the item; then click the close button 
- scroll down to see if the grid goes away 