### PR TITLE
Fixed typo in ci.yaml file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ on:
       - main
       - develop
       - 'release/*'
-      -
+
 env:
   MAIN_REPO: IN-CORE/incore-ui
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Community playbook link not working correctly
+
+
 ## [1.15.1] - 2025-07-31
 
 ### Added


### PR DESCRIPTION
There was a typo in ci.yaml that has been there for 4+ years. Until recently, it was ignored; however, it is giving build errors now and so I removed it. Please check to verify it wasn't providing some functionality I'm not aware of. Thanks!